### PR TITLE
Enable dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/website/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      npm-production:
+        patterns:
+          - "*"
   - package-ecosystem: "rust" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/website/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "rust" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,46 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
   - package-ecosystem: "npm"
-    directory: "/website/" # marketing website path
+    directory: "/website/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
       - "npm"
+    open-pull-requests-limit: 10
     groups:
       npm-production:
         patterns:
           - "*"
-  - package-ecosystem: "cargo" 
-    directory: "/" # app rust root path
+        dependency-type: "production"
+      npm-dev:
+        patterns:
+          - "*"
+        dependency-type: "development"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
       - "rust"
+    open-pull-requests-limit: 10
     groups:
       rust-production:
         patterns:
           - "*"
+        dependency-type: "production"
+      rust-dev:
+        patterns:
+          - "*"
+        dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/website/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/website/" # marketing website path
     schedule:
       interval: "weekly"
     labels:
@@ -16,8 +16,8 @@ updates:
       npm-production:
         patterns:
           - "*"
-  - package-ecosystem: "rust" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo" 
+    directory: "/" # app rust root path
     schedule:
       interval: "weekly"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      rust-production:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to automate dependency tracking across all three ecosystems in this repo. Closes #6 

Ecosystems covered:
- `cargo` — Rust app dependencies
- `npm` — Astro marketing website (`/website/`)
- `github-actions` — workflow actions (`checkout`, `cache`)

Config choices:
- Weekly cadence for all ecosystems
- Production and dev deps in separate groups, so a failing dev bump doesn't block a prod update
- `open-pull-requests-limit: 10` to avoid queue buildup
- Labels per ecosystem for easy triage

Signed-off-by: Gareth Evans <63365672+ggfevans@users.noreply.github.com>