### PR TITLE
Pin GitHub Actions to latest releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/website/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      npm-production:
+        patterns:
+          - "*"
   - package-ecosystem: "rust" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/website/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "rust" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,46 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
   - package-ecosystem: "npm"
-    directory: "/website/" # marketing website path
+    directory: "/website/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
       - "npm"
+    open-pull-requests-limit: 10
     groups:
       npm-production:
         patterns:
           - "*"
-  - package-ecosystem: "cargo" 
-    directory: "/" # app rust root path
+        dependency-type: "production"
+      npm-dev:
+        patterns:
+          - "*"
+        dependency-type: "development"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
       - "rust"
+    open-pull-requests-limit: 10
     groups:
       rust-production:
         patterns:
           - "*"
+        dependency-type: "production"
+      rust-dev:
+        patterns:
+          - "*"
+        dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/website/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/website/" # marketing website path
     schedule:
       interval: "weekly"
     labels:
@@ -16,8 +16,8 @@ updates:
       npm-production:
         patterns:
           - "*"
-  - package-ecosystem: "rust" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo" 
+    directory: "/" # app rust root path
     schedule:
       interval: "weekly"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      rust-production:
+        patterns:
+          - "*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,13 +26,13 @@ jobs:
         shell: bash
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy
 
       - name: Cache Cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Cache Cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Bump both Actions to their latest versions and switch from floating version tags to pinned commit SHAs for supply chain security. Closes #8 

- `actions/checkout`: `v6` → `v6.0.3` (`df4cb1c`)
- `actions/cache`: `v4` → `v5.0.5` (`27d5ce7f`)