### PR TITLE
test: adversarial tests for shell/XML escaping primitives

### DIFF
--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -6,7 +6,8 @@ use eternalmac::config::store::Store;
 use eternalmac::model::config::{ClientConfig, Config, Role, SessionConfig};
 use eternalmac::process::runner::{Output, Runner};
 use eternalmac::tooling::et::{
-    build_attach_args, build_attach_args_with_options, build_new_session_args_with_options,
+    build_attach_args, build_attach_args_with_options, build_new_session_args,
+    build_new_session_args_with_options,
 };
 
 struct FakeRunner {
@@ -116,6 +117,39 @@ fn attach_args_escape_single_quotes_in_session_names() {
     assert_eq!(
         build_attach_args("mac-mini", "dev's session"),
         vec!["mac-mini", "-c", "tmux attach -t 'dev'\\''s session'"]
+    );
+}
+
+#[test]
+fn attach_args_neutralize_command_injection_in_session_names() {
+    // A session name carrying shell metacharacters must stay confined to a
+    // single-quoted literal so the remote shell cannot execute it.
+    let args = build_attach_args("mac-mini", "default'; rm -rf ~ #");
+
+    assert_eq!(
+        args,
+        vec![
+            "mac-mini",
+            "-c",
+            "tmux attach -t 'default'\\''; rm -rf ~ #'",
+        ]
+    );
+    // The dangerous fragment must never appear outside the quoted literal.
+    assert!(!args[2].contains("default'; rm"));
+}
+
+#[test]
+fn new_session_args_neutralize_substitution_in_session_names() {
+    // Command/back-tick substitution is inert inside single quotes.
+    let args = build_new_session_args("mac-mini", "$(touch pwned)`id`");
+
+    assert_eq!(
+        args,
+        vec![
+            "mac-mini",
+            "-c",
+            "tmux new-session -d -s '$(touch pwned)`id`'",
+        ]
     );
 }
 

--- a/tests/launchd.rs
+++ b/tests/launchd.rs
@@ -61,3 +61,40 @@ fn plist_render_includes_environment_variables() {
         "<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>"
     ));
 }
+
+#[test]
+fn plist_render_escapes_xml_in_environment_variable_keys_and_values() {
+    let xml = render(&Definition {
+        label: "com.eternalmac.server".into(),
+        program_arguments: vec!["/opt/homebrew/bin/eternalMac".into()],
+        environment_variables: BTreeMap::from([(
+            String::from("EVIL&KEY<"),
+            String::from("v\"<>&'one"),
+        )]),
+        run_at_load: true,
+        keep_alive: true,
+    });
+
+    assert!(
+        xml.contains("<key>EVIL&amp;KEY&lt;</key><string>v&quot;&lt;&gt;&amp;&apos;one</string>")
+    );
+    assert!(!xml.contains("EVIL&KEY<"));
+}
+
+#[test]
+fn plist_render_neutralizes_structure_breakout_in_program_arguments() {
+    // A value attempting to close the <string> element and inject its own keys
+    // must be fully entity-encoded so the plist structure stays intact.
+    let xml = render(&Definition {
+        label: "com.eternalmac.server".into(),
+        program_arguments: vec!["evil</string><key>Injected</key><string>x".into()],
+        environment_variables: BTreeMap::new(),
+        run_at_load: true,
+        keep_alive: true,
+    });
+
+    assert!(xml.contains(
+        "<string>evil&lt;/string&gt;&lt;key&gt;Injected&lt;/key&gt;&lt;string&gt;x</string>"
+    ));
+    assert!(!xml.contains("</string><key>Injected</key>"));
+}

--- a/tests/tooling.rs
+++ b/tests/tooling.rs
@@ -229,3 +229,20 @@ fn interactive_authorize_key_args_disable_pubkey_and_send_remote_command() {
         .unwrap()
         .contains("ssh-ed25519 AAAAB3Nza key-comment"));
 }
+
+#[test]
+fn interactive_authorize_key_args_neutralize_injection_in_public_key() {
+    // The public key is interpolated into a remote shell command that appends
+    // to authorized_keys. A key carrying shell metacharacters must stay inside
+    // a single-quoted literal so it cannot break out and execute.
+    let args = interactive_authorize_key_args(
+        "devuser",
+        "mac-mini.example.ts.net",
+        "ssh-ed25519 AAAA'; rm -rf ~ #",
+    );
+    let remote_command = args.last().unwrap();
+
+    assert!(remote_command.contains("'ssh-ed25519 AAAA'\\''; rm -rf ~ #'"));
+    // The unescaped break-out fragment must never appear.
+    assert!(!remote_command.contains("AAAA'; rm"));
+}


### PR DESCRIPTION
## Summary

Extends adversarial test coverage of the two escaping primitives that gate all remote-command and plist generation. **Correction:** CI already exists (`.github/workflows/rust.yml`) — an earlier revision of this PR wrongly added a second workflow; that has been dropped. This PR is now tests-only, and they run under the existing CI.

Fills the previously-untested cases (single-quote and basic `<>&'"` escaping were already covered):
- `et::quote_shell_arg`: full shell-injection payloads (`;`, `$(...)`, backticks) in session names stay confined to a single-quoted literal.
- `ssh::interactive_authorize_key_args`: a public key carrying shell metacharacters is safely quoted in the `authorized_keys` append (previously only the benign case was tested).
- `launchd::escape_xml`: environment-variable key/value escaping, and `</string><key>` structure-breakout neutralization.

No runtime behavior change — test additions only.

## Test Plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 149 passed (5 new)
- [x] Runs under existing `.github/workflows/rust.yml`

Closes #13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify proper handling of special characters in tmux session names and arguments
  * Added test coverage for XML entity escaping in plist environment variables and program arguments
  * Added unit tests for shell metacharacter handling in command generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->