### PR TITLE
fix: false-degraded sync status and masked remote session-list failures

### DIFF
--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -10,7 +10,9 @@ use crate::tooling::et::{
     build_new_session_args_with_options as build_remote_new_session_args,
     SESSION_LIST_BEGIN_MARKER, SESSION_LIST_END_MARKER,
 };
-use crate::tooling::tmux::{list_sessions_args, new_session_args, parse_sessions};
+use crate::tooling::tmux::{
+    list_sessions_args, list_sessions_failed_without_server, new_session_args, parse_sessions,
+};
 
 fn run_checked<R: Runner>(runner: &R, program: &str, args: &[String]) -> Result<Output> {
     let output = runner.run(program, args)?;
@@ -84,12 +86,20 @@ pub fn list_with<R: Runner>(store: &Store, runner: &R) -> Result<Vec<String>> {
             server_ssh_user,
             server_etterminal_path,
         } => {
-            let output = run_checked(
-                runner,
-                "et",
-                &build_remote_list_sessions_args(server, server_ssh_user, server_etterminal_path),
-            )?;
-            Ok(parse_marked_remote_sessions(&output.stdout))
+            let args =
+                build_remote_list_sessions_args(server, server_ssh_user, server_etterminal_path);
+            let output = runner.run("et", &args)?;
+            if output.success {
+                Ok(parse_marked_remote_sessions(&output.stdout))
+            } else if list_sessions_failed_without_server(&output.stderr) {
+                // No tmux server / no sessions yet on the paired server: a
+                // legitimate empty result, mirroring the local server path.
+                Ok(Vec::new())
+            } else {
+                // A real remote failure (e.g. tmux missing, connection error):
+                // surface it instead of masking it as an empty list.
+                Err(command_failed("et", &args, &output))
+            }
         }
     }
 }

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -57,14 +57,8 @@ fn status_is_active(status: &str) -> bool {
         return false;
     }
 
-    let has_explicit_healthy_marker = ["watching for changes", "idle", "synchronized"]
-        .iter()
-        .any(|marker| normalized.contains(marker));
-    if !has_explicit_healthy_marker {
-        return false;
-    }
-
-    ![
+    // Genuine problem states: a sync reporting any of these is degraded.
+    let has_problem_marker = [
         "paused",
         "halted",
         "problem",
@@ -74,12 +68,30 @@ fn status_is_active(status: &str) -> bool {
         "disconnected",
         "reconnect",
         "reconnecting",
-        "scanning",
-        "staging",
-        "synchronizing",
-        "applying",
-        "waiting",
         "conflict",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker));
+    if has_problem_marker {
+        return false;
+    }
+
+    // Healthy steady states plus normal in-progress transfer phases. Transfer
+    // phases are routine operation, not degradation; classifying them as
+    // degraded makes health flap on every sync. "Scanning files" and "Staging
+    // files on beta" were observed live (mutagen 0.18.1); the rest are
+    // mutagen's documented transfer lifecycle.
+    [
+        "watching for changes",
+        "idle",
+        "synchronized",
+        "scanning",
+        "reconciling",
+        "staging",
+        "transitioning",
+        "applying",
+        "saving",
+        "synchronizing",
     ]
     .iter()
     .any(|marker| normalized.contains(marker))

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -8,7 +8,9 @@ use crate::model::config::Role;
 use crate::model::state::State;
 use crate::process::runner::{Output, Runner};
 use crate::tooling::tailscale::{parse_status_json, status_args};
-use crate::tooling::tmux::{list_sessions_args, new_session_args, parse_sessions};
+use crate::tooling::tmux::{
+    list_sessions_args, list_sessions_failed_without_server, new_session_args, parse_sessions,
+};
 
 #[derive(Debug, Clone)]
 pub struct ServerInput {
@@ -62,19 +64,6 @@ fn command_failed(program: &str, args: &[String], stderr: &str) -> anyhow::Error
     }
 
     anyhow!(message)
-}
-
-fn tmux_list_sessions_failed_without_server(stderr: &str) -> bool {
-    let normalized = stderr.trim().to_ascii_lowercase();
-    if normalized.is_empty() {
-        return false;
-    }
-
-    normalized.contains("no server running on")
-        || normalized.contains("failed to connect to server")
-        || (normalized.contains("error connecting to")
-            && (normalized.contains("no such file or directory")
-                || normalized.contains("connection refused")))
 }
 
 fn current_unix_seconds() -> Result<i64> {
@@ -141,7 +130,7 @@ pub fn run_once<R: Runner>(_paths: &Paths, store: &Store, runner: &R) -> Result<
     let tmux_output = runner.run("tmux", &tmux_list_args)?;
     let mut sessions = if tmux_output.success {
         parse_sessions(&tmux_output.stdout)
-    } else if tmux_list_sessions_failed_without_server(&tmux_output.stderr) {
+    } else if list_sessions_failed_without_server(&tmux_output.stderr) {
         vec![]
     } else {
         return Err(command_failed("tmux", &tmux_list_args, &tmux_output.stderr));

--- a/src/tooling/et.rs
+++ b/src/tooling/et.rs
@@ -52,8 +52,12 @@ pub fn build_list_sessions_args_with_options(
     server_ssh_user: Option<&str>,
     server_etterminal_path: Option<&str>,
 ) -> Vec<String> {
+    // Capture tmux's exit status and propagate it, so a failed `tmux
+    // list-sessions` surfaces as a command failure instead of being masked as
+    // an empty session list (the trailing `printf` would otherwise always
+    // make the remote command succeed).
     let command = format!(
-        "printf '{}\\n'; tmux list-sessions -F '#S'; printf '{}\\n'; exit",
+        "printf '{}\\n'; tmux list-sessions -F '#S'; status=$?; printf '{}\\n'; exit $status",
         SESSION_LIST_BEGIN_MARKER, SESSION_LIST_END_MARKER
     );
     build_remote_command_args_with_options(

--- a/src/tooling/tmux.rs
+++ b/src/tooling/tmux.rs
@@ -14,3 +14,19 @@ pub fn parse_sessions(stdout: &str) -> Vec<String> {
         .map(str::to_string)
         .collect()
 }
+
+/// True when a failed `tmux list-sessions` indicates "no tmux server / no
+/// sessions" rather than a real error. Used to treat the benign empty case as
+/// zero sessions while still surfacing genuine failures (e.g. tmux missing).
+pub fn list_sessions_failed_without_server(stderr: &str) -> bool {
+    let normalized = stderr.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    normalized.contains("no server running on")
+        || normalized.contains("failed to connect to server")
+        || (normalized.contains("error connecting to")
+            && (normalized.contains("no such file or directory")
+                || normalized.contains("connection refused")))
+}

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -750,3 +750,91 @@ fn client_run_once_marks_transient_sync_status_as_degraded() {
     assert_eq!(state.syncs[0].status, "degraded");
     assert_eq!(state.summary, "client daemon degraded");
 }
+
+// Real mutagen statuses observed during a normal transfer (mutagen 0.18.1):
+// "Scanning files" and "Staging files on beta". These are in-progress phases of
+// a healthy sync and must NOT be reported as degraded, or health flaps on every
+// transfer. See https://github.com/eternalMac/eternalMac issue for details.
+fn client_config_with_single_project_pair() -> Config {
+    Config {
+        role: Role::Client,
+        server: None,
+        client: Some(ClientConfig {
+            paired_server: "mac-mini.example.ts.net".into(),
+            server_ssh_user: None,
+            server_etterminal_path: None,
+            pinned: vec![],
+            sync_pairs: vec![SyncPairConfig {
+                name: "project".into(),
+                local: "/Users/me/project".into(),
+                remote: "mac-mini.example.ts.net:~/project".into(),
+                mode: "two-way-resolved".into(),
+                ignore_paths: vec![],
+                kind: None,
+                label: None,
+            }],
+        }),
+        session: SessionConfig { auto_attach: true },
+    }
+}
+
+fn run_client_once_with_sync_status(status_line: &str) -> State {
+    let tempdir = tempfile::tempdir().unwrap();
+    let paths = Paths::new(tempdir.path().to_path_buf());
+    let store = Store::new(paths.clone());
+    let runner = FakeRunner::default()
+        .with_response(
+            "tailscale",
+            status_args(),
+            Output {
+                stdout:
+                    r#"{"BackendState":"Running","Self":{"DNSName":"mac-mini.example.ts.net"}}"#
+                        .into(),
+                stderr: String::new(),
+                success: true,
+            },
+        )
+        .with_response(
+            "mutagen",
+            list_args(),
+            Output {
+                stdout: format!(
+                    "Name: project\nIdentifier: sync_project\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: {status_line}\n"
+                ),
+                stderr: String::new(),
+                success: true,
+            },
+        );
+
+    store
+        .save_config(&client_config_with_single_project_pair())
+        .unwrap();
+
+    eternalmac::daemon::client::run_once(&paths, &store, &runner).unwrap();
+    store.load_state().unwrap()
+}
+
+#[test]
+fn client_run_once_treats_scanning_transfer_as_active() {
+    let state = run_client_once_with_sync_status("Scanning files");
+
+    assert_eq!(state.syncs[0].status, "active");
+    assert!(state.healthy);
+    assert_eq!(state.summary, "client daemon healthy");
+}
+
+#[test]
+fn client_run_once_treats_staging_transfer_as_active() {
+    let state = run_client_once_with_sync_status("Staging files on beta");
+
+    assert_eq!(state.syncs[0].status, "active");
+    assert!(state.healthy);
+}
+
+#[test]
+fn client_run_once_still_marks_reconnecting_as_degraded() {
+    let state = run_client_once_with_sync_status("reconnecting");
+
+    assert_eq!(state.syncs[0].status, "degraded");
+    assert!(!state.healthy);
+}

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -169,10 +169,46 @@ fn session_list_uses_et_against_paired_server_when_client_config_exists() {
             "et".into(),
             build_remote_command_args(
                 "mac-mini",
-                "printf '__ETERNALMAC_SESSIONS_BEGIN__\\n'; tmux list-sessions -F '#S'; printf '__ETERNALMAC_SESSIONS_END__\\n'; exit"
+                "printf '__ETERNALMAC_SESSIONS_BEGIN__\\n'; tmux list-sessions -F '#S'; status=$?; printf '__ETERNALMAC_SESSIONS_END__\\n'; exit $status"
             )
         )]
     );
+}
+
+#[test]
+fn session_list_returns_empty_when_remote_has_no_tmux_server() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let paths = Paths::new(tempdir.path().to_path_buf());
+    let store = Store::new(paths);
+    save_config(&store, None, Some(vec![]));
+    // tmux exits non-zero with this stderr when no server is running
+    // (observed with tmux 3.6b); this is a legitimate empty result.
+    let runner = FakeRunner::failure_with_streams(
+        "__ETERNALMAC_SESSIONS_BEGIN__\n__ETERNALMAC_SESSIONS_END__\n",
+        "error connecting to /private/tmp/tmux-501/default (No such file or directory)",
+    );
+
+    let sessions = list_with(&store, &runner).unwrap();
+
+    assert!(sessions.is_empty());
+}
+
+#[test]
+fn session_list_errors_on_real_remote_failure_instead_of_reporting_empty() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let paths = Paths::new(tempdir.path().to_path_buf());
+    let store = Store::new(paths);
+    save_config(&store, None, Some(vec![]));
+    // A genuine failure (e.g. tmux not installed on the server) must surface,
+    // not be masked as an empty session list.
+    let runner = FakeRunner::failure_with_streams(
+        "__ETERNALMAC_SESSIONS_BEGIN__\n__ETERNALMAC_SESSIONS_END__\n",
+        "bash: tmux: command not found",
+    );
+
+    let result = list_with(&store, &runner);
+
+    assert!(result.is_err());
 }
 
 #[test]
@@ -202,7 +238,7 @@ fn session_list_uses_persisted_terminal_path() {
                 "mac-mini",
                 Some("devuser"),
                 Some("/opt/homebrew/bin/etterminal"),
-                "printf '__ETERNALMAC_SESSIONS_BEGIN__\\n'; tmux list-sessions -F '#S'; printf '__ETERNALMAC_SESSIONS_END__\\n'; exit"
+                "printf '__ETERNALMAC_SESSIONS_BEGIN__\\n'; tmux list-sessions -F '#S'; status=$?; printf '__ETERNALMAC_SESSIONS_END__\\n'; exit $status"
             )
         )]
     );

--- a/tests/tooling.rs
+++ b/tests/tooling.rs
@@ -5,7 +5,7 @@ use eternalmac::tooling::ssh::{
     render_managed_host_block, upsert_managed_host_block, validate_ssh_host, validate_ssh_user,
 };
 use eternalmac::tooling::tailscale::{detect_variant, parse_status_json, Variant};
-use eternalmac::tooling::tmux::parse_sessions;
+use eternalmac::tooling::tmux::{list_sessions_failed_without_server, parse_sessions};
 
 #[test]
 fn brew_install_args_split_formulae_and_casks() {
@@ -81,6 +81,26 @@ fn tmux_session_parser_ignores_blank_lines() {
         parse_sessions("default\npairing\n\n"),
         vec!["default".to_string(), "pairing".to_string()]
     );
+}
+
+#[test]
+fn tmux_no_server_stderr_is_recognized_but_real_errors_are_not() {
+    // Benign "no server / no sessions" cases.
+    assert!(list_sessions_failed_without_server(
+        "no server running on /tmp/tmux-501/default"
+    ));
+    assert!(list_sessions_failed_without_server(
+        "error connecting to /private/tmp/tmux-501/default (No such file or directory)"
+    ));
+    assert!(list_sessions_failed_without_server(
+        "failed to connect to server"
+    ));
+    // Genuine failures must NOT be treated as an empty session list.
+    assert!(!list_sessions_failed_without_server(
+        "bash: tmux: command not found"
+    ));
+    assert!(!list_sessions_failed_without_server("lost server"));
+    assert!(!list_sessions_failed_without_server(""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Two client health-reporting fixes. Each is an independent commit.

**1. Treat in-progress mutagen transfer phases as healthy** (`src/daemon/client.rs`)
`status_is_active` classified `scanning`/`staging`/`synchronizing`/`applying` as degraded and required a healthy marker, so a sync mid-transfer — mutagen reports `Scanning files` / `Staging files on beta` (verified live, mutagen 0.18.1) — was reported `degraded`, flipping daemon `healthy` to false and making `doctor` exit non-zero on every transfer/initial sync. Now split into problem markers (kept degraded) vs active markers (steady states + normal transfer lifecycle).

**2. Surface remote session-list failures instead of reporting empty** (`src/tooling/et.rs`, `src/commands/session.rs`)
The ET remote list command ended in a bare `exit`, returning the trailing `printf`'s always-success status, so a failed `tmux list-sessions` was masked as an empty list. Now propagate tmux's exit status; on failure, treat the known "no server / no sessions" stderr as a legitimate empty result and surface any other failure as an error — mirroring the existing server-side handling. The no-server predicate is hoisted into a shared `tooling::tmux::list_sessions_failed_without_server` (also de-duplicates the server-side copy).

## Test Plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo build --locked` / `cargo test --locked` — 150 passed (6 new)
- [x] New tests: `Scanning files`/`Staging files on beta` -> active; `reconnecting` -> degraded; remote list returns empty on no-server stderr, errors on real failure; unit test for the shared predicate
- [x] Behaviour verified live against mutagen 0.18.1 and tmux 3.6b

Closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session listing to properly handle scenarios where the tmux server is not running, returning an empty session list instead of surfacing an error.
  * Enhanced sync status detection to more accurately classify active versus degraded synchronization states across different transfer phases.
  * Better error handling that differentiates between "no sessions available" and actual command failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->