### PR TITLE
ci: disable GITHUB_TOKEN persistence in checkout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Build/test only: no later step performs authenticated git
+          # operations, so do not leave GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy


### PR DESCRIPTION
## Summary
Set `persist-credentials: false` on the `actions/checkout` step in `rust.yml`.

`actions/checkout` leaves `GITHUB_TOKEN` in `.git/config` by default so later steps can run authenticated git operations. The `build-and-test` job does none (fmt/clippy/build/test/smoke only), so the persisted token is unneeded attack surface — e.g. a dependency build script could read it. Disabling persistence removes that exposure with no functional change.

## Context
This originated as a review finding against a `ci.yml` workflow that was proposed and then dropped (it duplicated `rust.yml`). The finding no longer applies to `ci.yml` (the file does not exist), so it has been redirected to the equivalent, still-valid spot in the actual CI workflow.

## Test Plan
- [x] YAML parses; checkout step now has `with: persist-credentials: false`
- [x] No later step performs authenticated git operations, so behaviour is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security practices in CI/CD by preventing credentials from being retained in build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->