### PR TITLE
feat: doctor reports server-alive status when ET is unreachable (#3)

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,7 +5,7 @@ use crate::doctor::service::collect_issues;
 
 pub fn run() -> Result<()> {
     let context = AppContext::from_env()?;
-    let issues = collect_issues(&context.store)?;
+    let issues = collect_issues(&context.store, &context.runner)?;
 
     if issues.is_empty() {
         println!("no issues");

--- a/src/doctor/service.rs
+++ b/src/doctor/service.rs
@@ -4,12 +4,14 @@ use anyhow::Result;
 
 use crate::config::store::Store;
 use crate::model::config::{Config, Role};
+use crate::process::runner::Runner;
 use crate::status::service::daemon_heartbeat_stale;
+use crate::tooling::ping::alive_check_args;
 
 const CONFIG_MISSING_ISSUE: &str =
     "config missing: run `eternalMac setup server` or `eternalMac setup client`";
 
-pub fn collect_issues(store: &Store) -> Result<Vec<String>> {
+pub fn collect_issues<R: Runner>(store: &Store, runner: &R) -> Result<Vec<String>> {
     let mut issues = Vec::new();
 
     let config = match store.load_config() {
@@ -25,13 +27,18 @@ pub fn collect_issues(store: &Store) -> Result<Vec<String>> {
     };
 
     if let Some(config) = config.as_ref() {
-        inspect_state(store, config, &mut issues)?;
+        inspect_state(store, config, runner, &mut issues)?;
     }
 
     Ok(issues)
 }
 
-fn inspect_state(store: &Store, config: &Config, issues: &mut Vec<String>) -> Result<()> {
+fn inspect_state<R: Runner>(
+    store: &Store,
+    config: &Config,
+    runner: &R,
+    issues: &mut Vec<String>,
+) -> Result<()> {
     match store.load_state() {
         Ok(state) => {
             if role_name(&state.role) != role_name(&config.role) {
@@ -59,14 +66,18 @@ fn inspect_state(store: &Store, config: &Config, issues: &mut Vec<String>) -> Re
                     issues.push("tailscale not running".to_string());
                 }
                 if !state.server_reachable {
-                    let paired_server = config
-                        .client
-                        .as_ref()
-                        .map(|client| client.paired_server.as_str())
-                        .unwrap_or("unknown");
-                    issues.push(format!(
-                        "paired server unreachable over Eternal Terminal: {paired_server}"
-                    ));
+                    match config.client.as_ref() {
+                        Some(client) => {
+                            let paired_server = client.paired_server.as_str();
+                            issues.push(format!(
+                                "paired server unreachable over Eternal Terminal: {paired_server}"
+                            ));
+                            issues.push(server_alive_issue(runner, paired_server));
+                        }
+                        None => issues.push(
+                            "paired server unreachable over Eternal Terminal: unknown".to_string(),
+                        ),
+                    }
                 }
                 for sync in state.syncs.iter().filter(|sync| sync.status != "active") {
                     issues.push(format!("sync {}: {}", sync.status, sync.name));
@@ -82,6 +93,18 @@ fn inspect_state(store: &Store, config: &Config, issues: &mut Vec<String>) -> Re
     }
 
     Ok(())
+}
+
+fn server_alive_issue<R: Runner>(runner: &R, paired_server: &str) -> String {
+    match runner.run("ping", &alive_check_args(paired_server)) {
+        Ok(output) if output.success => format!(
+            "server alive: yes ({paired_server} responds to ping; the Eternal Terminal service may be down on the server — try `brew services restart et` there)"
+        ),
+        Ok(_) => format!(
+            "server alive: no ({paired_server} did not respond to ping; the server may be offline or asleep)"
+        ),
+        Err(error) => format!("server alive: unknown (could not run ping: {error})"),
+    }
 }
 
 fn state_missing_issue(config: &Config) -> String {

--- a/src/doctor/service.rs
+++ b/src/doctor/service.rs
@@ -95,14 +95,30 @@ fn inspect_state<R: Runner>(
     Ok(())
 }
 
+// macOS ping(8) exit codes: 0 = at least one reply, 2 = no replies; anything
+// else (e.g. 68 for an unresolvable host) means the probe itself failed.
+const PING_NO_REPLIES_EXIT_CODE: i32 = 2;
+
 fn server_alive_issue<R: Runner>(runner: &R, paired_server: &str) -> String {
     match runner.run("ping", &alive_check_args(paired_server)) {
         Ok(output) if output.success => format!(
             "server alive: yes ({paired_server} responds to ping; the Eternal Terminal service may be down on the server — try `brew services restart et` there)"
         ),
-        Ok(_) => format!(
+        Ok(output) if output.exit_code == Some(PING_NO_REPLIES_EXIT_CODE) => format!(
             "server alive: no ({paired_server} did not respond to ping; the server may be offline or asleep)"
         ),
+        Ok(output) => {
+            let detail = match output.exit_code {
+                Some(code) => format!("ping exited with code {code}"),
+                None => "ping terminated without an exit code".to_string(),
+            };
+            let stderr = output.stderr.trim();
+            if stderr.is_empty() {
+                format!("server alive: unknown ({detail})")
+            } else {
+                format!("server alive: unknown ({detail}: {stderr})")
+            }
+        }
         Err(error) => format!("server alive: unknown (could not run ping: {error})"),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod tooling {
     pub mod dependencies;
     pub mod et;
     pub mod mutagen;
+    pub mod ping;
     pub mod ssh;
     pub mod tailscale;
     pub mod tmux;

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -110,6 +110,10 @@ fn candidate_program_paths(program: &str) -> Vec<String> {
         candidates.push("/Applications/Tailscale.app/Contents/MacOS/Tailscale".to_string());
     }
 
+    if program == "ping" {
+        candidates.push("/sbin/ping".to_string());
+    }
+
     dedupe(candidates)
 }
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -9,6 +9,7 @@ pub struct Output {
     pub stdout: String,
     pub stderr: String,
     pub success: bool,
+    pub exit_code: Option<i32>,
 }
 
 pub trait Runner {
@@ -49,6 +50,7 @@ impl Runner for SystemRunner {
                         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
                         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
                         success: output.status.success(),
+                        exit_code: output.status.code(),
                     });
                 }
                 Err(error) if error.kind() == ErrorKind::NotFound => {
@@ -77,6 +79,7 @@ impl Runner for SystemRunner {
                         stdout: String::new(),
                         stderr: String::new(),
                         success: status.success(),
+                        exit_code: status.code(),
                     });
                 }
                 Err(error) if error.kind() == ErrorKind::NotFound => {
@@ -152,6 +155,19 @@ mod tests {
                 "/opt/homebrew/bin/tailscale".to_string(),
                 "/usr/local/bin/tailscale".to_string(),
                 "/Applications/Tailscale.app/Contents/MacOS/Tailscale".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidate_program_paths_include_sbin_ping() {
+        assert_eq!(
+            candidate_program_paths("ping"),
+            vec![
+                "ping".to_string(),
+                "/opt/homebrew/bin/ping".to_string(),
+                "/usr/local/bin/ping".to_string(),
+                "/sbin/ping".to_string(),
             ]
         );
     }

--- a/src/setup/client.rs
+++ b/src/setup/client.rs
@@ -687,6 +687,7 @@ mod tests {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             })
         }
     }
@@ -734,6 +735,7 @@ mod tests {
                     stdout: String::new(),
                     stderr: "Permission denied".into(),
                     success: false,
+                    exit_code: Some(1),
                 },
             },
             Stub {
@@ -743,6 +745,7 @@ mod tests {
                     stdout: String::new(),
                     stderr: String::new(),
                     success: true,
+                    exit_code: Some(0),
                 },
             },
         ]);

--- a/src/tooling/ping.rs
+++ b/src/tooling/ping.rs
@@ -1,0 +1,10 @@
+pub fn alive_check_args(host: &str) -> Vec<String> {
+    // macOS ping: one probe, give up after 3 seconds overall.
+    vec![
+        "-c".into(),
+        "1".into(),
+        "-t".into(),
+        "3".into(),
+        host.into(),
+    ]
+}

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -24,6 +24,7 @@ impl FakeRunner {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         }
     }
@@ -36,6 +37,7 @@ impl FakeRunner {
                 stdout: String::new(),
                 stderr: stderr.into(),
                 success: false,
+                exit_code: Some(1),
             },
         }
     }
@@ -48,6 +50,7 @@ impl FakeRunner {
                 stdout: stdout.into(),
                 stderr: stderr.into(),
                 success: false,
+                exit_code: Some(1),
             },
         }
     }

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -45,6 +45,7 @@ impl Runner for FakeRunner {
             stdout: String::new(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         })
     }
 }
@@ -64,6 +65,7 @@ fn server_run_once_refreshes_state_and_marks_daemon_healthy() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -73,6 +75,7 @@ fn server_run_once_refreshes_state_and_marks_daemon_healthy() {
                 stdout: "default\npairing\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -124,6 +127,7 @@ fn client_run_once_refreshes_sync_state_from_config_and_mutagen_listing() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -133,6 +137,7 @@ fn client_run_once_refreshes_sync_state_from_config_and_mutagen_listing() {
                 stdout: "Name: project\nIdentifier: sync_project\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: Watching for changes\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -215,6 +220,7 @@ fn client_run_once_marks_server_unreachable_when_et_probe_fails() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -224,6 +230,7 @@ fn client_run_once_marks_server_unreachable_when_et_probe_fails() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -233,6 +240,7 @@ fn client_run_once_marks_server_unreachable_when_et_probe_fails() {
                 stdout: "unable to connect".into(),
                 stderr: String::new(),
                 success: false,
+                exit_code: Some(1),
             },
         );
 
@@ -280,6 +288,7 @@ fn client_run_once_matches_sync_names_exactly() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -289,6 +298,7 @@ fn client_run_once_matches_sync_names_exactly() {
                 stdout: "Name: project\nIdentifier: sync_project\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: Watching for changes\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -350,6 +360,7 @@ fn client_run_once_matches_syncs_by_name_and_endpoints_not_first_name_match() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -359,6 +370,7 @@ fn client_run_once_matches_syncs_by_name_and_endpoints_not_first_name_match() {
                 stdout: "Name: project\nIdentifier: sync_wrong\nLabels: None\nAlpha:\n    URL: /Users/me/other-project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/other-project\n    Connection state: Connected\nStatus: Watching for changes\n\nName: project\nIdentifier: sync_right\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: reconnecting\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -578,6 +590,7 @@ fn server_run_once_reconciles_missing_default_session() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -587,6 +600,7 @@ fn server_run_once_reconciles_missing_default_session() {
                 stdout: "pairing\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -596,6 +610,7 @@ fn server_run_once_reconciles_missing_default_session() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -640,6 +655,7 @@ fn server_run_once_treats_tmux_no_server_as_empty_and_reconciles() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -649,6 +665,7 @@ fn server_run_once_treats_tmux_no_server_as_empty_and_reconciles() {
                 stdout: String::new(),
                 stderr: "no server running on /tmp/tmux-501/default".into(),
                 success: false,
+                exit_code: Some(1),
             },
         )
         .with_response(
@@ -658,6 +675,7 @@ fn server_run_once_treats_tmux_no_server_as_empty_and_reconciles() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 
@@ -706,6 +724,7 @@ fn client_run_once_marks_transient_sync_status_as_degraded() {
                         .into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         )
         .with_response(
@@ -715,6 +734,7 @@ fn client_run_once_marks_transient_sync_status_as_degraded() {
                 stdout: "Name: project\nIdentifier: sync_project\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: reconnecting\n".into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         );
 

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -65,6 +65,7 @@ impl Runner for FakeRunner {
             stdout: String::new(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         })
     }
 }
@@ -115,6 +116,7 @@ fn doctor_reports_server_alive_when_host_pings_but_et_is_unreachable() {
             stdout: String::new(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         },
     );
 
@@ -140,6 +142,7 @@ fn doctor_reports_server_not_alive_when_ping_gets_no_response() {
             stdout: String::new(),
             stderr: "Request timeout".into(),
             success: false,
+            exit_code: Some(2),
         },
     );
 
@@ -148,6 +151,31 @@ fn doctor_reports_server_not_alive_when_ping_gets_no_response() {
     assert!(issues
         .iter()
         .any(|issue| issue.starts_with("server alive: no")));
+}
+
+#[test]
+fn doctor_reports_server_alive_unknown_when_ping_fails_for_other_reasons() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = client_store_with_unreachable_server(&tempdir);
+    let runner = FakeRunner::default().with_response(
+        "ping",
+        alive_check_args("mac-mini.example.ts.net"),
+        Output {
+            stdout: String::new(),
+            stderr: "ping: cannot resolve mac-mini.example.ts.net: Unknown host".into(),
+            success: false,
+            exit_code: Some(68),
+        },
+    );
+
+    let issues = collect_issues(&store, &runner).unwrap();
+
+    let unknown_line = issues
+        .iter()
+        .find(|issue| issue.starts_with("server alive: unknown"))
+        .expect("expected a `server alive: unknown` line");
+    assert!(unknown_line.contains("68"));
+    assert!(unknown_line.contains("cannot resolve"));
 }
 
 #[test]

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -1,16 +1,208 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Result};
 use assert_cmd::Command;
 use eternalmac::app::paths::Paths;
 use eternalmac::config::store::Store;
+use eternalmac::doctor::service::collect_issues;
 use eternalmac::model::config::{ClientConfig, Config, Role, ServerConfig, SessionConfig};
 use eternalmac::model::state::{State, SyncPairState};
+use eternalmac::process::runner::{Output, Runner};
+use eternalmac::tooling::ping::alive_check_args;
 use predicates::str::contains;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn current_unix_seconds() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs() as i64
+}
+
+#[derive(Debug, Default)]
+struct FakeRunner {
+    responses: BTreeMap<(String, Vec<String>), Output>,
+    failing_programs: BTreeSet<String>,
+    calls: RefCell<Vec<(String, Vec<String>)>>,
+}
+
+impl FakeRunner {
+    fn with_response(mut self, program: &str, args: Vec<String>, output: Output) -> Self {
+        self.responses.insert((program.to_string(), args), output);
+        self
+    }
+
+    fn with_failing_program(mut self, program: &str) -> Self {
+        self.failing_programs.insert(program.to_string());
+        self
+    }
+
+    fn calls(&self) -> Vec<(String, Vec<String>)> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl Runner for FakeRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<Output> {
+        self.calls
+            .borrow_mut()
+            .push((program.to_string(), args.to_vec()));
+
+        if self.failing_programs.contains(program) {
+            return Err(anyhow!("command not found: {program}"));
+        }
+
+        if let Some(output) = self
+            .responses
+            .get(&(program.to_string(), args.to_vec()))
+            .cloned()
+        {
+            return Ok(output);
+        }
+
+        Ok(Output {
+            stdout: String::new(),
+            stderr: String::new(),
+            success: true,
+        })
+    }
+}
+
+fn client_store_with_unreachable_server(tempdir: &tempfile::TempDir) -> Store {
+    let paths = Paths::new(tempdir.path().to_path_buf());
+    let store = Store::new(paths);
+    store
+        .save_config(&Config {
+            role: Role::Client,
+            server: None,
+            client: Some(ClientConfig {
+                paired_server: "mac-mini.example.ts.net".into(),
+                server_ssh_user: None,
+                server_etterminal_path: None,
+                pinned: vec![],
+                sync_pairs: vec![],
+            }),
+            session: SessionConfig { auto_attach: true },
+        })
+        .unwrap();
+    store
+        .save_state(&State {
+            role: Role::Client,
+            tailscale_ok: true,
+            server_reachable: false,
+            healthy: false,
+            summary: "client daemon degraded: Eternal Terminal cannot reach paired server".into(),
+            tailscale_dns: Some("mac-mini.example.ts.net".into()),
+            daemon_healthy: true,
+            daemon_heartbeat_unix: current_unix_seconds(),
+            default_session_present: false,
+            known_sessions: vec![],
+            syncs: vec![],
+        })
+        .unwrap();
+    store
+}
+
+#[test]
+fn doctor_reports_server_alive_when_host_pings_but_et_is_unreachable() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = client_store_with_unreachable_server(&tempdir);
+    let runner = FakeRunner::default().with_response(
+        "ping",
+        alive_check_args("mac-mini.example.ts.net"),
+        Output {
+            stdout: String::new(),
+            stderr: String::new(),
+            success: true,
+        },
+    );
+
+    let issues = collect_issues(&store, &runner).unwrap();
+
+    assert!(issues.iter().any(|issue| issue
+        .contains("paired server unreachable over Eternal Terminal: mac-mini.example.ts.net")));
+    let alive_line = issues
+        .iter()
+        .find(|issue| issue.starts_with("server alive: yes"))
+        .expect("expected a `server alive: yes` line");
+    assert!(alive_line.contains("brew services restart et"));
+}
+
+#[test]
+fn doctor_reports_server_not_alive_when_ping_gets_no_response() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = client_store_with_unreachable_server(&tempdir);
+    let runner = FakeRunner::default().with_response(
+        "ping",
+        alive_check_args("mac-mini.example.ts.net"),
+        Output {
+            stdout: String::new(),
+            stderr: "Request timeout".into(),
+            success: false,
+        },
+    );
+
+    let issues = collect_issues(&store, &runner).unwrap();
+
+    assert!(issues
+        .iter()
+        .any(|issue| issue.starts_with("server alive: no")));
+}
+
+#[test]
+fn doctor_reports_server_alive_unknown_when_ping_cannot_run() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = client_store_with_unreachable_server(&tempdir);
+    let runner = FakeRunner::default().with_failing_program("ping");
+
+    let issues = collect_issues(&store, &runner).unwrap();
+
+    assert!(issues
+        .iter()
+        .any(|issue| issue.starts_with("server alive: unknown")));
+}
+
+#[test]
+fn doctor_does_not_ping_when_server_is_reachable() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let paths = Paths::new(tempdir.path().to_path_buf());
+    let store = Store::new(paths);
+    store
+        .save_config(&Config {
+            role: Role::Client,
+            server: None,
+            client: Some(ClientConfig {
+                paired_server: "mac-mini.example.ts.net".into(),
+                server_ssh_user: None,
+                server_etterminal_path: None,
+                pinned: vec![],
+                sync_pairs: vec![],
+            }),
+            session: SessionConfig { auto_attach: true },
+        })
+        .unwrap();
+    store
+        .save_state(&State {
+            role: Role::Client,
+            tailscale_ok: true,
+            server_reachable: true,
+            healthy: true,
+            summary: "client daemon healthy".into(),
+            tailscale_dns: Some("mac-mini.example.ts.net".into()),
+            daemon_healthy: true,
+            daemon_heartbeat_unix: current_unix_seconds(),
+            default_session_present: false,
+            known_sessions: vec![],
+            syncs: vec![],
+        })
+        .unwrap();
+    let runner = FakeRunner::default();
+
+    let issues = collect_issues(&store, &runner).unwrap();
+
+    assert!(issues.is_empty());
+    assert!(runner.calls().is_empty());
 }
 
 #[test]
@@ -197,7 +389,8 @@ fn doctor_reports_client_server_unreachable() {
         .failure()
         .stdout(contains(
             "paired server unreachable over Eternal Terminal: mac-mini.example.ts.net",
-        ));
+        ))
+        .stdout(contains("server alive:"));
 }
 
 #[test]

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -22,6 +22,7 @@ impl FakeRunner {
                 stdout: stdout.into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         }
     }
@@ -33,6 +34,7 @@ impl FakeRunner {
                 stdout: String::new(),
                 stderr: stderr.into(),
                 success: false,
+                exit_code: Some(1),
             },
         }
     }
@@ -44,6 +46,7 @@ impl FakeRunner {
                 stdout: stdout.into(),
                 stderr: stderr.into(),
                 success: false,
+                exit_code: Some(1),
             },
         }
     }

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -38,6 +38,7 @@ impl FakeRunner {
                 stdout: String::new(),
                 stderr: stderr.to_string(),
                 success: false,
+                exit_code: Some(1),
             },
         }])
     }
@@ -84,6 +85,7 @@ impl Runner for FakeRunner {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: false,
+                exit_code: Some(1),
             });
         }
 
@@ -102,6 +104,7 @@ impl Runner for FakeRunner {
             stdout,
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         })
     }
 }
@@ -291,6 +294,7 @@ fn server_setup_installs_only_missing_dependencies() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         },
         Stub {
@@ -303,6 +307,7 @@ fn server_setup_installs_only_missing_dependencies() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         },
         Stub {
@@ -315,6 +320,7 @@ fn server_setup_installs_only_missing_dependencies() {
                 stdout: String::new(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         },
     ]);
@@ -353,6 +359,7 @@ fn server_setup_errors_when_tailscale_dns_is_unavailable() {
             stdout: r#"{"BackendState":"Running","Self":{}}"#.to_string(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         },
     }]);
 
@@ -467,6 +474,7 @@ fn server_setup_skips_bootstrap_when_default_session_already_exists() {
             stdout: "default\npairing\n".to_string(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         },
     }]);
 
@@ -812,6 +820,7 @@ fn client_setup_skips_mutagen_create_when_matching_sync_already_exists() {
             stdout: "Name: project\nIdentifier: sync_123\nLabels: None\nAlpha:\n    URL: /Users/me/project\n    Connection state: Connected\nBeta:\n    URL: mac-mini.example.ts.net:~/project\n    Connection state: Connected\nStatus: Watching for changes\n".to_string(),
             stderr: String::new(),
             success: true,
+            exit_code: Some(0),
         },
     }]);
 
@@ -909,6 +918,7 @@ fn server_setup_ignores_client_unload_not_loaded_error() {
             stdout: String::new(),
             stderr: "Could not find specified service".to_string(),
             success: false,
+            exit_code: Some(1),
         },
     }]);
 
@@ -993,6 +1003,7 @@ fn client_setup_ignores_server_unload_not_loaded_error() {
             stdout: String::new(),
             stderr: "Could not find specified service".to_string(),
             success: false,
+            exit_code: Some(1),
         },
     }]);
 
@@ -1211,6 +1222,7 @@ fn client_setup_mutagen_failure_after_partial_creation_persists_progress() {
             stdout: String::new(),
             stderr: "mutagen failed".to_string(),
             success: false,
+            exit_code: Some(1),
         },
     }]);
 

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -23,6 +23,7 @@ impl FakeRunner {
                 stdout: stdout.into(),
                 stderr: String::new(),
                 success: true,
+                exit_code: Some(0),
             },
         }
     }
@@ -34,6 +35,7 @@ impl FakeRunner {
                 stdout: String::new(),
                 stderr: stderr.into(),
                 success: false,
+                exit_code: Some(1),
             },
         }
     }


### PR DESCRIPTION
## Summary
- When a client's paired server is unreachable over Eternal Terminal, `doctor` now pings the host (`ping -c 1 -t 3`) to determine whether the server itself is online — directly addressing the scenario in #3 where the host was up but the `et` service had crashed.
- Adds a `server alive:` status line to doctor output:
  - `server alive: yes (...)` — host responds to ping; suggests `brew services restart et` on the server (the exact fix from #3)
  - `server alive: no (...)` — host did not respond; server may be offline or asleep
  - `server alive: unknown (...)` — ping itself could not run; doctor never crashes while diagnosing
- The ping probe only runs when `server_reachable` is already false, so the healthy path has zero added overhead.
- `/sbin/ping` added to runner path candidates (it lives outside Homebrew prefixes).

## Test Plan
- [x] 4 new tests in `tests/doctor.rs` covering alive/not-alive/unknown and no-ping-when-reachable (FakeRunner-based, following the `tests/daemon.rs` pattern)
- [x] Existing binary test extended to assert the `server alive:` line
- [x] `cargo test` — 148 passed
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean
- [x] CodeRabbit CLI review — 0 findings

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Doctor diagnostics now perform live ping checks and report "server alive: yes/no/unknown" alongside paired-server reachability, with tailored restart and troubleshooting hints.
* **Bug Fixes / Improvements**
  * More accurate detection of ping outcomes and better-lived status reporting to reduce false positives when a paired server is unreachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->