### PR TITLE
Sharpen README launch surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.codex/
+/.superpowers/
 /docs/
 /Initial_Design.md
 /spec.md

--- a/README.md
+++ b/README.md
@@ -1,58 +1,47 @@
 # eternalMac
 
-`eternalMac` turns a Mac Mini into a personal devserver for a laptop.
+Make your laptop disposable.
 
-The current MVP is a macOS-only Rust CLI that wraps:
+`eternalMac` turns a Mac Mini into an always-on devserver your laptop just attaches to. Sleep the laptop, change networks, reboot, or move to another machine; your real dev session keeps running on the Mac Mini.
 
-- Eternal Terminal for resilient remote shell access
-- `tmux` for named remote sessions
-- Mutagen for file sync
-- Tailscale for private reachability
-- `launchd` for always-on background operation
+[![Rust CI](https://github.com/eternalMac/eternalMac/actions/workflows/rust.yml/badge.svg)](https://github.com/eternalMac/eternalMac/actions/workflows/rust.yml)
+[![GitHub release](https://img.shields.io/github/v/release/eternalMac/eternalMac)](https://github.com/eternalMac/eternalMac/releases)
+[![License](https://img.shields.io/github/license/eternalMac/eternalMac)](./LICENSE)
+[![Docs](https://img.shields.io/badge/docs-eternalmac.dev-2563eb)](https://eternalmac.dev/docs)
 
-Product docs: https://eternalmac.dev/docs
+![eternalMac architecture](assets/readme/architecture.svg)
 
-## Current Scope
+![eternalMac attach terminal proof](assets/readme/terminal-proof.svg)
 
-Today, the repo provides:
+## Why
 
-- `eternalMac setup server` to configure a Mac Mini as the devserver
-- `eternalMac setup client` to configure a laptop as the thin client
-- `eternalMac attach [session]` to connect to a named remote `tmux` session
-- `eternalMac attach -n <session>` to create a new remote `tmux` session and attach to it
-- `eternalMac session ...` to list, create, pin, and unpin sessions
-- `eternalMac sync ...` to add and inspect sync pairs
-- `eternalMac status` and `eternalMac doctor` for local health and setup checks
+Modern development sessions are long-running. Agents keep working overnight, builds take time, and context lives in terminals. A laptop is the worst place for that state: it sleeps, disconnects, gets moved, and runs out of battery.
 
-The tool currently assumes Homebrew-managed dependencies and installs or checks:
+`eternalMac` makes the Mac Mini the stable machine and the laptop the thin client.
 
-- `et`
-- `tmux`
-- `mutagen`
-- `tailscale-app`
+- Keep Claude/Codex/OpenCode-style agent sessions running on the Mac Mini.
+- Reconnect to named remote `tmux` sessions with `eternalMac attach`.
+- Sync project files continuously with Mutagen.
+- Reach the Mac Mini privately through Tailscale, without opening public ports.
 
-## Platform
+Under the hood, `eternalMac` wires together Eternal Terminal, `tmux`, Mutagen, Tailscale, and `launchd` behind one CLI.
 
-- macOS only
-- Homebrew-first workflow
-- Single-user personal devserver model
+## Install
 
-The Mac Mini must have Remote Login enabled because Eternal Terminal and Mutagen both rely on SSH for setup and handshaking. Server setup may ask for your macOS password to start Homebrew's root Eternal Terminal service. Client setup asks for the server SSH username, creates a dedicated passwordless `eternalMac` SSH key, authorizes it with a one-time password prompt when needed, and records the remote `etterminal` path used by ET.
-
-## Quick Start
-
-Install from the eternalMac Homebrew tap in one command:
+Install from the eternalMac Homebrew tap:
 
 ```bash
 brew install eternalmac/eternalmac/eternalmac
 ```
 
-No separate `brew tap` command is required for the fully qualified install command above. Homebrew will tap `eternalmac/eternalmac` automatically. If you prefer the shorter install command later, run:
+No separate `brew tap` is required for that fully qualified install command. If you prefer the shorter command later:
 
 ```bash
 brew tap eternalmac/eternalmac
 brew install eternalmac
 ```
+
+## Quick Start
 
 On the Mac Mini:
 
@@ -66,16 +55,44 @@ On the laptop:
 eternalMac setup client --server <tailscale-dns-name>
 ```
 
-Then attach:
+Attach to the default remote session:
 
 ```bash
 eternalMac attach
 ```
 
-Create a fresh remote session and attach immediately:
+Create a named remote session and attach immediately:
 
 ```bash
-eternalMac attach -n feature-branch
+eternalMac attach -n overnight-agent
+```
+
+Full setup and troubleshooting docs:
+
+https://eternalmac.dev/docs
+
+## What It Gives You
+
+### Resilient Remote Sessions
+
+`eternalMac attach` connects through Eternal Terminal into a named `tmux` session on the Mac Mini. If the laptop sleeps or changes networks, reconnect to the same session.
+
+### File Sync
+
+Project sync uses Mutagen:
+
+```bash
+eternalMac sync add project --local ~/project --remote ~/project
+```
+
+If a specific project needs exclusions, pass Mutagen ignore patterns:
+
+```bash
+eternalMac sync add project \
+  --local ~/project \
+  --remote ~/project \
+  --ignore .env \
+  --ignore "secrets/"
 ```
 
 ### DotSync
@@ -84,11 +101,26 @@ During `eternalMac setup client`, you can optionally enable DotSync. DotSync det
 
 DotSync is off by default. It uses a curated allowlist instead of syncing every hidden file in your home directory, and it excludes common auth, cache, log, telemetry, and machine-identity files.
 
-Full setup and troubleshooting docs:
+### Health Checks
 
-https://eternalmac.dev/docs
+```bash
+eternalMac status
+eternalMac doctor
+```
 
-## Command Surface
+`doctor` exits non-zero when it finds issues, making it usable for smoke checks and automation gates.
+
+## Requirements
+
+- Apple Silicon Mac Mini as the server
+- Apple Silicon macOS laptop as the client
+- Homebrew
+- Tailscale account and both machines in the same tailnet
+- macOS Remote Login enabled on the Mac Mini
+
+The published Homebrew formula is currently Apple Silicon only. Intel Mac support is not promised yet.
+
+## Commands
 
 ```bash
 eternalMac setup server
@@ -110,7 +142,23 @@ eternalMac status
 eternalMac doctor
 ```
 
-`eternalMac doctor` exits non-zero when it prints issues, making it suitable for release smoke checks and automation gates.
+## FAQ
+
+### Why not just SSH into tmux?
+
+You can. `eternalMac` is for the setup you would otherwise keep rebuilding by hand: resilient shell transport, named sessions, file sync, private reachability, launchd agents, status, and doctor checks.
+
+### Why Tailscale?
+
+The Mac Mini should be reachable from anywhere without opening public SSH ports. Tailscale gives `eternalMac` a private network path and stable DNS name.
+
+### Does project sync exclude secrets by default?
+
+No. Normal project sync is user-directed full-tree sync. If you ask to sync a project, `eternalMac` syncs that project. Use `--ignore` for project-specific exclusions. DotSync is different: it is curated and excludes common auth/cache/machine-state files by default.
+
+### Does this replace cloud dev environments?
+
+No. It is a personal devserver workflow for people who already have a Mac Mini and want their own hardware to be the always-on machine.
 
 ## Development
 
@@ -130,6 +178,12 @@ Run the smoke check:
 
 ```bash
 bash scripts/smoke/bootstrap.sh
+```
+
+Check repository hygiene:
+
+```bash
+bash scripts/check-no-tracked-ignored.sh
 ```
 
 ## Packaging

--- a/assets/readme/architecture.svg
+++ b/assets/readme/architecture.svg
@@ -1,0 +1,64 @@
+<svg width="1200" height="560" viewBox="0 0 1200 560" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">eternalMac architecture</title>
+  <desc id="desc">A MacBook thin client connects through Tailscale to an always-on Mac Mini devserver running Eternal Terminal, tmux, Mutagen, and launchd.</desc>
+  <rect width="1200" height="560" rx="32" fill="#07111F"/>
+  <path d="M0 420C170 350 270 470 410 400C545 333 630 210 775 260C930 315 1005 205 1200 160V560H0V420Z" fill="#0E2238"/>
+  <path d="M120 92C230 28 365 35 470 115C586 203 685 202 820 126C930 64 1060 66 1160 130" stroke="#1D3B5B" stroke-width="2"/>
+
+  <text x="72" y="72" fill="#F7FAFC" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="34" font-weight="800">Make your laptop disposable.</text>
+  <text x="72" y="112" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18">Your Mac Mini keeps the real dev environment alive. Your laptop just attaches.</text>
+
+  <g transform="translate(78 178)">
+    <rect x="0" y="0" width="300" height="230" rx="24" fill="#F8FAFC"/>
+    <rect x="38" y="42" width="224" height="132" rx="12" fill="#0F172A"/>
+    <rect x="70" y="74" width="160" height="16" rx="8" fill="#34D399"/>
+    <rect x="70" y="106" width="125" height="12" rx="6" fill="#93C5FD"/>
+    <rect x="70" y="132" width="178" height="12" rx="6" fill="#CBD5E1"/>
+    <path d="M92 190H208L232 220H68L92 190Z" fill="#CBD5E1"/>
+    <text x="32" y="278" fill="#F7FAFC" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="24" font-weight="800">MacBook Air</text>
+    <text x="32" y="309" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15">Sleep, travel, switch networks, reboot.</text>
+    <text x="32" y="333" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15">Then run eternalMac attach.</text>
+  </g>
+
+  <g transform="translate(460 188)">
+    <rect x="0" y="0" width="280" height="175" rx="26" fill="#123250" stroke="#2C5D89" stroke-width="2"/>
+    <circle cx="140" cy="68" r="44" fill="#60A5FA"/>
+    <path d="M117 71L133 87L164 50" stroke="#07111F" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="62" y="136" fill="#F7FAFC" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="25" font-weight="800">Tailscale</text>
+    <text x="54" y="164" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15">Private tailnet, no open ports</text>
+  </g>
+
+  <path d="M390 276H448" stroke="#60A5FA" stroke-width="5" stroke-linecap="round"/>
+  <path d="M435 261L455 276L435 291" stroke="#60A5FA" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M753 276H842" stroke="#60A5FA" stroke-width="5" stroke-linecap="round"/>
+  <path d="M829 261L849 276L829 291" stroke="#60A5FA" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <g transform="translate(850 148)">
+    <rect x="0" y="0" width="280" height="300" rx="34" fill="#E5E7EB"/>
+    <rect x="64" y="38" width="152" height="190" rx="22" fill="#111827"/>
+    <circle cx="140" cy="80" r="18" fill="#34D399"/>
+    <rect x="96" y="120" width="88" height="12" rx="6" fill="#64748B"/>
+    <rect x="84" y="150" width="112" height="12" rx="6" fill="#64748B"/>
+    <rect x="98" y="180" width="84" height="12" rx="6" fill="#64748B"/>
+    <rect x="108" y="242" width="64" height="14" rx="7" fill="#9CA3AF"/>
+    <text x="14" y="357" fill="#F7FAFC" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="24" font-weight="800">Mac Mini devserver</text>
+    <text x="14" y="388" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15">Always-on sessions, files, agents, builds.</text>
+  </g>
+
+  <g transform="translate(82 480)">
+    <rect x="0" y="0" width="245" height="40" rx="20" fill="#123250"/>
+    <text x="22" y="26" fill="#D8F3FF" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700">Eternal Terminal: resilient shell</text>
+  </g>
+  <g transform="translate(348 480)">
+    <rect x="0" y="0" width="205" height="40" rx="20" fill="#123250"/>
+    <text x="22" y="26" fill="#D8F3FF" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700">tmux: named sessions</text>
+  </g>
+  <g transform="translate(574 480)">
+    <rect x="0" y="0" width="202" height="40" rx="20" fill="#123250"/>
+    <text x="22" y="26" fill="#D8F3FF" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700">Mutagen: file sync</text>
+  </g>
+  <g transform="translate(797 480)">
+    <rect x="0" y="0" width="250" height="40" rx="20" fill="#123250"/>
+    <text x="22" y="26" fill="#D8F3FF" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700">launchd: background health</text>
+  </g>
+</svg>

--- a/assets/readme/terminal-proof.svg
+++ b/assets/readme/terminal-proof.svg
@@ -1,0 +1,28 @@
+<svg width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">eternalMac terminal reconnect demo</title>
+  <desc id="desc">A terminal panel showing eternalMac attach reconnecting to a named session on a Mac Mini where an overnight agent is still running.</desc>
+  <rect width="1200" height="520" rx="30" fill="#050B14"/>
+  <rect x="58" y="48" width="1084" height="424" rx="22" fill="#0B1220" stroke="#233249" stroke-width="2"/>
+  <rect x="58" y="48" width="1084" height="58" rx="22" fill="#111827"/>
+  <circle cx="95" cy="77" r="8" fill="#F87171"/>
+  <circle cx="124" cy="77" r="8" fill="#FBBF24"/>
+  <circle cx="153" cy="77" r="8" fill="#34D399"/>
+  <text x="188" y="83" fill="#CBD5E1" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="16">MacBook Air -> eternalMac -> Mac Mini</text>
+
+  <text x="92" y="155" fill="#94A3B8" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22"># new coffee shop, different network, laptop just woke up</text>
+  <text x="92" y="205" fill="#60A5FA" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="24">$</text>
+  <text x="124" y="205" fill="#E5E7EB" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="24">eternalMac attach -n overnight-agent</text>
+
+  <text x="92" y="260" fill="#34D399" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22">connected: mac-mini.tailnet.ts.net</text>
+  <text x="92" y="300" fill="#34D399" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22">session: overnight-agent</text>
+  <text x="92" y="340" fill="#A7F3D0" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22">codex: still running task 17/42</text>
+  <text x="92" y="380" fill="#A7F3D0" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22">mutagen: project files are in sync</text>
+  <text x="92" y="420" fill="#E5E7EB" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22">tmux: exactly where you left off</text>
+
+  <rect x="785" y="150" width="276" height="250" rx="22" fill="#101C2D" stroke="#264360" stroke-width="2"/>
+  <text x="823" y="202" fill="#F8FAFC" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="27" font-weight="800">The money shot</text>
+  <text x="823" y="244" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="17">Sleep the laptop.</text>
+  <text x="823" y="278" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="17">Change networks.</text>
+  <text x="823" y="312" fill="#B7C6D8" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="17">Attach again.</text>
+  <text x="823" y="358" fill="#34D399" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="17" font-weight="700">Your session survived.</text>
+</svg>


### PR DESCRIPTION
## Summary
- Rework README above the fold around the disposable-laptop positioning
- Add reviewable SVG hero assets for architecture and terminal proof
- Add .superpowers/ to .gitignore for local visual/launch drafts
- Update GitHub repo description and discovery topics separately via gh repo edit

## Verification
- xmllint --noout assets/readme/architecture.svg assets/readme/terminal-proof.svg
- bash scripts/check-no-tracked-ignored.sh
- git diff --check
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- bash scripts/smoke/bootstrap.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with improved organization and clearer messaging
  * Added "Why," "Install," and "Quick Start" sections with practical examples
  * Introduced "Health Checks," "Requirements," and "FAQ" sections for better guidance
  * Enhanced File Sync documentation with configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->